### PR TITLE
Allowing multivalue params

### DIFF
--- a/src/QueryAuth/ParameterCollection.php
+++ b/src/QueryAuth/ParameterCollection.php
@@ -45,10 +45,29 @@ class ParameterCollection implements \IteratorAggregate, \ArrayAccess, \Countabl
                 continue;
             }
 
-            $normalized .= rawurlencode($key) . '=' . rawurlencode($value) . '&';
+            $normalized .= $this->rawurlencode($key, $value);
         }
 
         return substr($normalized, 0, -1);
+    }
+    
+    public function rawurlencode($key, $value)
+    {
+        $normalized = '';
+        
+        if (is_array($value)) {
+            foreach ($value as $childKey => $childValue) {
+                $childKey = str_replace('[]', '', $key) . '[' . $childKey . ']';
+                
+                $normalized .= $this->rawurlencode($childKey, $childValue);
+            }
+            
+            return $normalized;
+        }
+        
+        $normalized .= rawurlencode($key) . '=' . rawurlencode($value) . '&';
+        
+        return $normalized;
     }
 
     /**

--- a/tests/QueryAuth/Tests/ParameterCollectionTest.php
+++ b/tests/QueryAuth/Tests/ParameterCollectionTest.php
@@ -21,6 +21,24 @@ class ParameterCollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $actual);
     }
+    
+    public function testNormalizeMultiValues()
+    {
+        $collection = new ParameterCollection(
+            array(
+                'tags' => array('rock', 'sam'),
+                'posts' => array(
+                    array('id' => 1, 'title' => "Single post title!"),
+                    array('id' => 2, 'title' => 'Another post')
+                )
+            )
+        );
+
+        $expected = 'posts%5B0%5D%5Bid%5D=1&posts%5B0%5D%5Btitle%5D=Single%20post%20title%21&posts%5B1%5D%5Bid%5D=2&posts%5B1%5D%5Btitle%5D=Another%20post&tags%5B0%5D=rock&tags%5B1%5D=sam';
+        $actual = $collection->normalize();
+
+        $this->assertEquals($expected, $actual);
+    }
 
     public function testNormalizeSkipsSignature()
     {


### PR DESCRIPTION
In the future, we may use the function _http_build_query()_. When PHP is >= 5.4.0 we can pass the **enc_type** to set **RFC 3986**.

http://us2.php.net/http_build_query
