### PR TITLE
Update to allow later versions of RandomLib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "ircmaxell/random-lib": "v1.0.0"
+        "ircmaxell/random-lib": "~v1.0"
     },
     "require-dev": {
         "guzzle/guzzle": ">=3.7.0,<=3.9.9",

--- a/tests/QueryAuth/KeyGeneratorTest.php
+++ b/tests/QueryAuth/KeyGeneratorTest.php
@@ -24,12 +24,12 @@ class KeyGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateSecret()
     {
         $secret = $this->keyGenerator->generateSecret();
-        $this->assertRegexp('/^[0-9A-Za-z\/\.]{60}$/', $secret);
+        $this->assertRegexp('/^[0-9A-Za-z\/\.\+]{60}$/', $secret);
     }
 
     public function testGenerateNonce()
     {
         $secret = $this->keyGenerator->generateNonce();
-        $this->assertRegexp('/^[0-9A-Za-z\/\.]{64}$/', $secret);
+        $this->assertRegexp('/^[0-9A-Za-z\/\.\+]{64}$/', $secret);
     }
 }


### PR DESCRIPTION
Updated composer.json to allow for later versions of RandomLib.   Had to change the KeyGeneratorTest class so it allows + as one of the allowed characters.  I was trying to install another library that depended on RandomLib, but it required v1.2 and so I had a conflict between the two.  This updates the composer.json file to be a little more accommodating to the RandomLib version.

If this PR doesn't cause any issues I wouldn't mind a quick release turnaround since this is a blocker for me on a project.